### PR TITLE
subLessons não são lidas pelo parseLesson

### DIFF
--- a/src/courses/sigaa-lesson-parser.ts
+++ b/src/courses/sigaa-lesson-parser.ts
@@ -100,7 +100,15 @@ export class SigaaLessonParser implements LessonParser {
 
   parseLessonPages(pageLessonsList: Page, pageLessonsPaged: Page): void {
     const lessonsElements = this.getElements(pageLessonsList);
-
+    lessonsElements.map((lessonElement) => {
+      const subElements = pageLessonsList
+        .$(lessonElement)
+        .find('.topico-aula')
+        .toArray();
+      subElements.map((subElement) => {
+        lessonsElements.splice(lessonsElements.indexOf(subElement), 1);
+      });
+    });
     const lessonIdsWithReferences = this.parsePagedPage(pageLessonsPaged);
     this.resources.lessons.keepOnly(
       lessonsElements.map(
@@ -144,7 +152,7 @@ export class SigaaLessonParser implements LessonParser {
       titleFull.lastIndexOf('(') + 1,
       titleFull.lastIndexOf(')')
     );
-
+    
     const [startDate, endDate] = this.parserDate(lessonDatesString);
 
     const title = titleFull.slice(0, titleFull.lastIndexOf('(')).trim();
@@ -253,6 +261,8 @@ export class SigaaLessonParser implements LessonParser {
             this.forumsIdIndex++;
             const forum = this.resources.forums.upsert(forumOptions);
             lessonAttachments.push(forum);
+            // eslint-disable-next-line no-empty
+          } else if (iconSrc.includes('user_comment.png')) {
           } else if (iconSrc.includes('portal_turma/site_add.png')) {
             const link = this.parseAttachmentLink(page, attachmentElement);
             lessonAttachments.push(link);
@@ -416,8 +426,8 @@ export class SigaaLessonParser implements LessonParser {
         .find('span[id] > span[id]');
       title = this.parser.removeTagsHtml(titleElement.html());
       const srcIframe = page.$(attachmentElement).find('iframe').attr('src');
-      if (!srcIframe) throw new Error('SIGAA: Video iframe without url.');
-      src = srcIframe;
+      if (!srcIframe) src = '';
+      else src = srcIframe;
     }
 
     return {


### PR DESCRIPTION
Por algum motivo, em alguns tópicos de aula estão com tópicos em seu conteúdo, sem titulo ocasionando erro no parseLesson a tentar ler o titulo e datas.
![Captura de tela de 2022-11-27 13-37-40](https://user-images.githubusercontent.com/45330928/204152435-45f44176-438b-4914-8be2-ec147e7397e6.png)
![Captura de tela de 2022-11-27 13-37-47](https://user-images.githubusercontent.com/45330928/204152445-4a9ab3bc-4bc5-45c2-8d37-c5e633428fd8.png)
Para solucionar, antes de entrar no método é retirado os "subTópicos" verificando se há uma div com a classe .topico-aula dentro do tópico.
